### PR TITLE
<fix> update to work with geoip2 0.3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Emacs droppings
+*~
+
+# Cabal sandbox should not be committed
+.cabal-sandbox/
+cabal.sandbox.config
+
+# Build output
+dist/
+
+# The default geoip database--you should always fetch this yourself instead of
+# it being checked in
+GeoLite2-City.mmdb

--- a/Main.hs
+++ b/Main.hs
@@ -23,8 +23,8 @@ instance ToJSON Result where
                              , "continent"     .= geoContinent x
                              , "countryCode"   .= geoCountryISO x
                              , "countryName"   .= geoCountry x
-                             , "latitude"      .= (fst <$> geoLocation x)
-                             , "longitude"     .= (snd <$> geoLocation x)
+                             , "latitude"      .= (locationLatitude <$> geoLocation x)
+                             , "longitude"     .= (locationLongitude <$> geoLocation x)
                              , "postalCode"    .= geoPostalCode x
                              , "region"        .= (fst <$> (listToMaybe $ geoSubdivisions x))
                              , "regionName"    .= (snd <$> (listToMaybe $ geoSubdivisions x))

--- a/geode.cabal
+++ b/geode.cabal
@@ -1,9 +1,18 @@
 name:                geode
-version:             0.1.0.0
+synopsis:            Udacity's GeoIP location service
+description:
+  Geode is a simple web service that returns geographical information about an IP using MaxMind's GeoIP2 City database.
+  .
+  Geode can look up a specific IP or the IP associated with the request. In the latter case, it honors Berlioz's
+  X-Forwarded-For header if present.
+  .
+  See the readme in the Git repository for more details.
+homepage:            https://github.com/udacity/geode
+version:             0.1.0.1
 license:             ISC
 license-file:        LICENSE
 author:              James Earl Douglas
-maintainer:          james.douglas@udacity.com
+maintainer:          owen@udacity.com
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/geode.cabal
+++ b/geode.cabal
@@ -15,7 +15,7 @@ executable geode
   build-depends:     base
                      , scotty
                      , aeson
-                     , geoip2
+                     , geoip2 >= 0.3.0.0
                      , iproute
                      , http-types
                      , text


### PR DESCRIPTION
`geoLocation` now returns a `Location` instead of `(latitude, longitude)`.

Also add a gitignore file for basic sanity.