### PR TITLE
Feature/udacity cors policy

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 
 import Data.Aeson (ToJSON, toJSON, (.=), object)
 import Data.GeoIP2


### PR DESCRIPTION
At the request of @thedeerchild, I've added the `X-XSRF-TOKEN` header to the Udacity CORS policy. I've also made it very easy to add additional cors tweaks in the future by introducing a udacityCorsResourcePolicy.

To make the syntax slightly less obnoxious, I added `-XRecordWildCards`. If @ods94065 doesn't want me to introduce it (some people hate it), I'll be happy to rewrite it without the extension.

_I was not given a test case by @thedeerchild, so I am not sure if this meets his requirements._ I've read the docs and made sure the software builds and runs, but can't be sure I addressed the issue. I've included him as a reviewer to help validate.